### PR TITLE
added support to specify url titles

### DIFF
--- a/pocket-cli.py
+++ b/pocket-cli.py
@@ -172,7 +172,7 @@ def main():
     parser = argparse.ArgumentParser(description=('A command line tool'
         ' to manage your pocket items'))
     parser.add_argument('-a', '--add', metavar='URL', nargs='+',
-        help='add the URL(s) to your pocket')
+        help='add the URL(s) to your pocket, titles can optionally be specified in the format <url>@<title>')
     parser.add_argument('-t', '--tag', metavar='TAG', nargs='+',
         help='add the TAG to the current item (specified by --add)')
     parser.add_argument('-u', '--unread',


### PR DESCRIPTION
Hi,

Thanks for this really useful utility!

I've added support to specify titles for urls. It can be used by giving urls in the format `<url>@<title>` with the `-a` parameter, like this:

`pocket-cli.py -a  'http://test.com@a title for the article'`

Cheers
